### PR TITLE
prep-release-notes: start/end reversed

### DIFF
--- a/prep-release-notes.py
+++ b/prep-release-notes.py
@@ -86,7 +86,7 @@ def print_notes(start_manifest, end_manifest):
         ncommits = len(commits)
 
         if ncommits >= 2:
-            sc, ec = commits[0], commits[-1]
+            sc, ec = commits[-1], commits[0]
             changes = '''\
 {} patches total:
 


### PR DESCRIPTION
The commit listings are showing "start" and "end" reversed.

Fix this by reversing the dict constructors.

Signed-off-by: Michael Scott <mike@foundries.io>